### PR TITLE
Fix an issue with trailing path separators in the `--cache-dir` argument.

### DIFF
--- a/internal/cachedirectory/cachedirectory.go
+++ b/internal/cachedirectory/cachedirectory.go
@@ -25,7 +25,7 @@ type CacheDirectory struct {
 
 func NewCacheDirectory(path string) CacheDirectory {
 	return CacheDirectory{
-		path: path,
+		path: filepath.Clean(path),
 	}
 }
 

--- a/internal/cachedirectory/cachedirectory_test.go
+++ b/internal/cachedirectory/cachedirectory_test.go
@@ -81,3 +81,10 @@ func TestErrorIfPushNonExistent(t *testing.T) {
 	err := cacheDirectory.CheckOrCreateVersionFile(false, aVersion)
 	require.EqualError(t, err, errorPushNonCache)
 }
+
+func TestCreateCacheDirectoryWithTrailingSlash(t *testing.T) {
+	temporaryDirectory := test.CreateTemporaryDirectory(t)
+	cacheDirectory := NewCacheDirectory(path.Join(temporaryDirectory, "cache") + string(os.PathSeparator))
+	err := cacheDirectory.CheckOrCreateVersionFile(true, aVersion)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This fixes an issue where using a non-existent cache directory behaves differently depending on whether it has a trailing slash.

Before this change, using a trailing slash would always give an error because we check if the parent (as determined by `filepath.Dir(...)` exists before creating the cache directory. When a path has a trailing slash, `filepath.Dir(...)` returns the input path. This is a Go bug in my opinion.

To work around this issue, I've called `filepath.Clean(...)` on the path before we initialize the cache, which strips any trailing slashes. I've also added a test for this case.