### PR TITLE
Allow providing a token for accessing GitHub.com.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ From a machine with access to both GitHub.com and GitHub Enterprise Server use t
 
 **Optional Arguments:**
 * `--cache-dir` - A temporary directory in which to store data downloaded from GitHub.com before it is uploaded to GitHub Enterprise Server. If not specified a directory next to the sync tool will be used.
+* `--source-token` - A token to access the API of GitHub.com. This is normally not required, but can be provided if you have issues with API rate limiting. If provided, it should have the `public_repo` scope.
 * `--destination-repository` - The name of the repository in which to create or update the CodeQL Action. If not specified `github/codeql-action` will be used.
 
 ### I don't have a machine that can access both GitHub.com and GitHub Enterprise Server.
@@ -29,6 +30,7 @@ From a machine with access to GitHub.com use the `./codeql-action-sync pull` com
 
 **Optional Arguments:**
 * `--cache-dir` - The directory in which to store data downloaded from GitHub.com. If not specified a directory next to the sync tool will be used.
+* `--source-token` - A token to access the API of GitHub.com. This is normally not required, but can be provided if you have issues with API rate limiting. If provided, it should have the `public_repo` scope.
 
 Next copy the sync tool and cache directory to another machine which has access to GitHub Enterprise Server.
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -13,12 +13,16 @@ var pullCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		return pull.Pull(cmd.Context(), cacheDirectory)
+		return pull.Pull(cmd.Context(), cacheDirectory, pullFlags.sourceToken)
 	},
 }
 
-type pullFlagFields struct{}
+type pullFlagFields struct {
+	sourceToken string
+}
 
 var pullFlags = pullFlagFields{}
 
-func (f *pullFlagFields) Init(cmd *cobra.Command) {}
+func (f *pullFlagFields) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.sourceToken, "source-token", "", "A token to access the API of GitHub.com. This is normally not required, but can be provided if you have issues with API rate limiting.")
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -14,7 +14,7 @@ var syncCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		err := pull.Pull(cmd.Context(), cacheDirectory)
+		err := pull.Pull(cmd.Context(), cacheDirectory, pullFlags.sourceToken)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This should hopefully cover people who want better reliability when running the tool from a shared IP address and run into rate limit issues.

Closes #5.