### PR TITLE
Implement some primitive cache locking.

### DIFF
--- a/internal/cachedirectory/cachedirectory_test.go
+++ b/internal/cachedirectory/cachedirectory_test.go
@@ -88,3 +88,14 @@ func TestCreateCacheDirectoryWithTrailingSlash(t *testing.T) {
 	err := cacheDirectory.CheckOrCreateVersionFile(true, aVersion)
 	require.NoError(t, err)
 }
+
+func TestLocking(t *testing.T) {
+	temporaryDirectory := test.CreateTemporaryDirectory(t)
+	cacheDirectory := NewCacheDirectory(path.Join(temporaryDirectory, "cache"))
+	require.NoError(t, cacheDirectory.CheckOrCreateVersionFile(true, aVersion))
+	require.NoError(t, cacheDirectory.Lock())
+	require.NoError(t, cacheDirectory.Lock())
+	require.Error(t, cacheDirectory.CheckLock())
+	require.NoError(t, cacheDirectory.Unlock())
+	require.NoError(t, cacheDirectory.CheckLock())
+}

--- a/internal/pull/pull.go
+++ b/internal/pull/pull.go
@@ -237,6 +237,10 @@ func Pull(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, sou
 	if err != nil {
 		return err
 	}
+	err = cacheDirectory.Lock()
+	if err != nil {
+		return err
+	}
 
 	var tokenClient *http.Client
 	if sourceToken != "" {
@@ -263,6 +267,11 @@ func Pull(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, sou
 		}
 	}
 	err = pullService.pullReleases()
+	if err != nil {
+		return err
+	}
+
+	err = cacheDirectory.Unlock()
 	if err != nil {
 		return err
 	}

--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -291,6 +291,10 @@ func Push(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, des
 	if err != nil {
 		return err
 	}
+	err = cacheDirectory.CheckLock()
+	if err != nil {
+		return err
+	}
 
 	destinationURL = strings.TrimRight(destinationURL, "/")
 	tokenSource := oauth2.StaticTokenSource(


### PR DESCRIPTION
This locks the cache directory when a `pull` command starts and unlocks it when it `succeeds`. This prevents accidentally pushing an incomplete cache directory.

Closes #8.