### PR TITLE
Implement a safety check to ensure we're not force-pushing over a non-Action repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ From a machine with access to both GitHub.com and GitHub Enterprise Server use t
 * `--cache-dir` - A temporary directory in which to store data downloaded from GitHub.com before it is uploaded to GitHub Enterprise Server. If not specified a directory next to the sync tool will be used.
 * `--source-token` - A token to access the API of GitHub.com. This is normally not required, but can be provided if you have issues with API rate limiting. If provided, it should have the `public_repo` scope.
 * `--destination-repository` - The name of the repository in which to create or update the CodeQL Action. If not specified `github/codeql-action` will be used.
+* `--force` - By default the tool will not overwrite existing repositories. Providing this flag will allow it to.
 
 ### I don't have a machine that can access both GitHub.com and GitHub Enterprise Server.
 From a machine with access to GitHub.com use the `./codeql-action-sync pull` command to download a copy of the CodeQL Action and bundles to a local folder.
@@ -45,6 +46,7 @@ Now use the `./codeql-action-sync push` command to upload the CodeQL Action and 
 **Optional Arguments:**
 * `--cache-dir` - The directory to which the Action was previously downloaded.
 * `--destination-repository` - The name of the repository in which to create or update the CodeQL Action. If not specified `github/codeql-action` will be used.
+* `--force` - By default the tool will not overwrite existing repositories. Providing this flag will allow it to.
 
 ## Contributing
 For more details on contributing improvements to this tool, see our [contributor guide](CONTRIBUTING.md).

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -13,7 +13,7 @@ var pushCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		return push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository)
+		return push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.force)
 	},
 }
 
@@ -21,6 +21,7 @@ type pushFlagFields struct {
 	destinationURL        string
 	destinationToken      string
 	destinationRepository string
+	force                 bool
 }
 
 var pushFlags = pushFlagFields{}
@@ -31,4 +32,5 @@ func (f *pushFlagFields) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.destinationToken, "destination-token", "", "A token to access the API on the GitHub Enterprise instance.")
 	cmd.MarkFlagRequired("destination-token")
 	cmd.Flags().StringVar(&f.destinationRepository, "destination-repository", "github/codeql-action", "The name of the repository to create on GitHub Enterprise.")
+	cmd.Flags().BoolVar(&f.force, "force", false, "Replace the existing repository even if it was not created by the sync tool.")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,7 +18,7 @@ var syncCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository)
+		err = push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.force)
 		if err != nil {
 			return err
 		}

--- a/internal/push/push_test/action-cache-initial/git/config
+++ b/internal/push/push_test/action-cache-initial/git/config
@@ -2,6 +2,3 @@
 	repositoryformatversion = 0
 	filemode = true
 	bare = true
-[remote "enterprise"]
-	url = /tmp/codeql-action-sync-tests128816160/target
-	fetch = +refs/heads/*:refs/remotes/enterprise/*


### PR DESCRIPTION
This ensures that if the repository we are pushing to already exists that it was created by the sync tool. It does this by checking the "homepage" property that we always set to the GitHub.com URL of the repository containing the sync tool.

It also adds a `--force` flag that can be used to override this check. This might be useful when the user running the tool is not allowed to make repositories themselves but instead has to have an administrator create it for them.

Closes #20.