### PR TITLE
Fix an issue with the tests where they update a file every time they are run.

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -162,6 +162,11 @@ func (pushService *pushService) pushGit(repository *github.Repository, initialPu
 			return errors.Wrap(err, "Error pushing Action to GitHub Enterprise Server.")
 		}
 	}
+
+	err = gitRepository.DeleteRemote(remoteName)
+	if err != nil {
+		return errors.Wrap(err, "Error removing repository remote.")
+	}
 	return nil
 }
 

--- a/internal/push/push_test/action-cache-initial/git/config
+++ b/internal/push/push_test/action-cache-initial/git/config
@@ -2,6 +2,3 @@
 	repositoryformatversion = 0
 	filemode = true
 	bare = true
-[remote "enterprise"]
-	url = /tmp/codeql-action-sync-tests128816160/target
-	fetch = +refs/heads/*:refs/remotes/enterprise/*


### PR DESCRIPTION
Running the tests currently modifies the Action cache, which is pretty annoying. To avoid this we can remove the Git remote created by the push command once we've used it to push the required refs.

Unfortunately `go-git` does not seem to support pushing to a remote without explicitly adding it to the config.