### PR TITLE
Make common errors easier to read.

### DIFF
--- a/internal/cachedirectory/cachedirectory_test.go
+++ b/internal/cachedirectory/cachedirectory_test.go
@@ -95,7 +95,7 @@ func TestLocking(t *testing.T) {
 	require.NoError(t, cacheDirectory.CheckOrCreateVersionFile(true, aVersion))
 	require.NoError(t, cacheDirectory.Lock())
 	require.NoError(t, cacheDirectory.Lock())
-	require.Error(t, cacheDirectory.CheckLock())
+	require.EqualError(t, cacheDirectory.CheckLock(), errorCacheLocked)
 	require.NoError(t, cacheDirectory.Unlock())
 	require.NoError(t, cacheDirectory.CheckLock())
 }

--- a/internal/githubapiutil/githubapiutil.go
+++ b/internal/githubapiutil/githubapiutil.go
@@ -1,0 +1,28 @@
+package githubapiutil
+
+import (
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+)
+
+const xOAuthScopesHeader = "X-OAuth-Scopes"
+
+func MissingAllScopes(response *github.Response, requiredAnyScopes ...string) bool {
+	if response == nil {
+		return false
+	}
+	if len(response.Header.Values(xOAuthScopesHeader)) == 0 {
+		return false
+	}
+	actualScopes := strings.Split(response.Header.Get(xOAuthScopesHeader), ",")
+	for _, actualScope := range actualScopes {
+		actualScope = strings.Trim(actualScope, " ")
+		for _, requiredAnyScope := range requiredAnyScopes {
+			if actualScope == requiredAnyScope {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/githubapiutil/githubapiutil_test.go
+++ b/internal/githubapiutil/githubapiutil_test.go
@@ -1,0 +1,25 @@
+package githubapiutil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/go-github/v32/github"
+)
+
+func TestHasAnyScopes(t *testing.T) {
+	response := github.Response{
+		Response: &http.Response{Header: http.Header{}},
+	}
+
+	response.Header.Set(xOAuthScopesHeader, "gist, notifications, admin:org, repo")
+	require.False(t, MissingAllScopes(&response, "public_repo", "repo"))
+
+	response.Header.Set(xOAuthScopesHeader, "gist, notifications, public_repo, admin:org")
+	require.False(t, MissingAllScopes(&response, "public_repo", "repo"))
+
+	response.Header.Set(xOAuthScopesHeader, "gist, notifications, admin:org")
+	require.True(t, MissingAllScopes(&response, "public_repo", "repo"))
+}


### PR DESCRIPTION
This updates "expected' error messages to not have stack traces. It also adds a few new error messages for common failure cases. 

Closes #13.