### PR TITLE
Remove the Darwin 386 build.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,9 @@ before:
 builds:
   - goos: [linux, darwin, windows]
     goarch: [386, amd64, arm64]
+    ignore:
+      - goos: darwin
+        goarch: 386
     ldflags:
       - -X github.com/github/codeql-action-sync/internal/version.version={{.Version}}
       - -X github.com/github/codeql-action-sync/internal/version.commit={{.Commit}}


### PR DESCRIPTION
Go 1.15 has removed support for building 32-bit macOS binaries, so it probably makes sense to stop releasing binaries for this platform too.