### PR TITLE
Add a flag to allow for pushing Git contents to GitHub Enterprise over SSH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ From a machine with access to both GitHub.com and GitHub Enterprise Server use t
 * `--source-token` - A token to access the API of GitHub.com. This is normally not required, but can be provided if you have issues with API rate limiting. The token does not need to have any scopes.
 * `--destination-repository` - The name of the repository in which to create or update the CodeQL Action. If not specified `github/codeql-action` will be used.
 * `--force` - By default the tool will not overwrite existing repositories. Providing this flag will allow it to.
+* `--push-ssh` - Push Git contents over SSH rather than HTTPS. To use this option you must have SSH access to your GitHub Enterprise instance configured.
 
 ### I don't have a machine that can access both GitHub.com and GitHub Enterprise Server.
 From a machine with access to GitHub.com use the `./codeql-action-sync pull` command to download a copy of the CodeQL Action and bundles to a local folder.
@@ -47,6 +48,7 @@ Now use the `./codeql-action-sync push` command to upload the CodeQL Action and 
 * `--cache-dir` - The directory to which the Action was previously downloaded.
 * `--destination-repository` - The name of the repository in which to create or update the CodeQL Action. If not specified `github/codeql-action` will be used.
 * `--force` - By default the tool will not overwrite existing repositories. Providing this flag will allow it to.
+* `--push-ssh` - Push Git contents over SSH rather than HTTPS. To use this option you must have SSH access to your GitHub Enterprise instance configured.
 
 ## Contributing
 For more details on contributing improvements to this tool, see our [contributor guide](CONTRIBUTING.md).

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -13,7 +13,7 @@ var pushCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		return push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.force)
+		return push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.force, pushFlags.pushSSH)
 	},
 }
 
@@ -22,6 +22,7 @@ type pushFlagFields struct {
 	destinationToken      string
 	destinationRepository string
 	force                 bool
+	pushSSH               bool
 }
 
 var pushFlags = pushFlagFields{}
@@ -33,4 +34,5 @@ func (f *pushFlagFields) Init(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("destination-token")
 	cmd.Flags().StringVar(&f.destinationRepository, "destination-repository", "github/codeql-action", "The name of the repository to create on GitHub Enterprise.")
 	cmd.Flags().BoolVar(&f.force, "force", false, "Replace the existing repository even if it was not created by the sync tool.")
+	cmd.Flags().BoolVar(&f.pushSSH, "push-ssh", false, "Push Git contents over SSH rather than HTTPS. To use this option you must have SSH access to your GitHub Enterprise instance configured.")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,7 +18,7 @@ var syncCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.force)
+		err = push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.force, pushFlags.pushSSH)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This adds an option to push to GitHub Enterprise over SSH. The reason for this is as an escape hatch for people who are unable to push over HTTPS.

It requires that the SSH key already be trusted by the machine doing the pushing and that your SSH key is already on the target GitHub Enterprise instance, but for most people who want to push via SSH this is hopefully already the case.