### PR TITLE
Fix the formatting of argument parsing errors.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,8 @@ func (f *rootFlagFields) Init(cmd *cobra.Command) error {
 	cmd.PersistentFlags().StringVar(&f.cacheDir, "cache-dir", defaultCacheDir, "The path to a local directory to cache the Action in.")
 
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		cmd.PrintErr(err)
+		cmd.PrintErrln(err)
+		cmd.PrintErrln()
 		cmd.PrintErr(cmd.UsageString())
 		return SilentErr
 	})


### PR DESCRIPTION
This fixes there being no new-line between argument parsing errors and the usage information by switching from printing the error with `PrintErr(...)` to `PrintErrln(...)`.

I've also added an extra new-line just to make it a bit more clear what the error was.