### PR TITLE
Tidy up Pkger install.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: 1.14.7
       - name: Install Pkger
-        run: go get github.com/markbates/pkger/cmd/pkger
+        run: go install --mod=readonly github.com/markbates/pkger/cmd/pkger
       - name: Build
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: 1.14.7
       - name: Install Pkger
-        run: go get github.com/markbates/pkger/cmd/pkger
+        run: go install --mod=readonly github.com/markbates/pkger/cmd/pkger
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
This fixes the Pkger binary being upgraded in CI rather than using the version from `go.mod`.