### PR TITLE
Use an updated copy of `golangci/golangci-lint-action`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             exit 1
           fi
       - name: Lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
 


### PR DESCRIPTION
This fixes an error in the linting workflow due to GitHub Actions command deprecations.