### PR TITLE
Allow specifying the destination token as an environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ From a machine with access to both GitHub.com and GitHub Enterprise Server use t
 
 **Required Arguments:**
 * `--destination-url` - The URL of the GitHub Enterprise Server instance to push the Action to.
-* `--destination-token` - A [Personal Access Token](https://docs.github.com/en/enterprise/user/github/authenticating-to-github/creating-a-personal-access-token) for the destination GitHub Enterprise Server instance. If the destination repository is in an organization that does not yet exist or that you are not an owner of, your token will need to have the `site_admin` scope in order to create the organization or update the repository in it. The organization can also be created manually or an existing organization that you own can be used, in which case the `repo` and `workflow` scopes are sufficient.
+* `--destination-token` - A [Personal Access Token](https://docs.github.com/en/enterprise/user/github/authenticating-to-github/creating-a-personal-access-token) for the destination GitHub Enterprise Server instance. If the destination repository is in an organization that does not yet exist or that you are not an owner of, your token will need to have the `site_admin` scope in order to create the organization or update the repository in it. The organization can also be created manually or an existing organization that you own can be used, in which case the `repo` and `workflow` scopes are sufficient. The token can also be provided by setting the `CODEQL_ACTION_SYNC_TOOL_DESTINATION_TOKEN` environment variable.
 
 **Optional Arguments:**
 * `--cache-dir` - A temporary directory in which to store data downloaded from GitHub.com before it is uploaded to GitHub Enterprise Server. If not specified a directory next to the sync tool will be used.
@@ -43,7 +43,7 @@ Now use the `./codeql-action-sync push` command to upload the CodeQL Action and 
 
 **Required Arguments:**
 * `--destination-url` - The URL of the GitHub Enterprise Server instance to push the Action to.
-* `--destination-token` - A [Personal Access Token](https://docs.github.com/en/enterprise/user/github/authenticating-to-github/creating-a-personal-access-token) for the destination GitHub Enterprise Server instance. If the destination repository is in an organization that does not yet exist or that you are not an owner of, your token will need to have the `site_admin` scope in order to create the organization or update the repository in it. The organization can also be created manually or an existing organization that you own can be used, in which case the `repo` and `workflow` scopes are sufficient.
+* `--destination-token` - A [Personal Access Token](https://docs.github.com/en/enterprise/user/github/authenticating-to-github/creating-a-personal-access-token) for the destination GitHub Enterprise Server instance. If the destination repository is in an organization that does not yet exist or that you are not an owner of, your token will need to have the `site_admin` scope in order to create the organization or update the repository in it. The organization can also be created manually or an existing organization that you own can be used, in which case the `repo` and `workflow` scopes are sufficient. The token can also be provided by setting the `CODEQL_ACTION_SYNC_TOOL_DESTINATION_TOKEN` environment variable.
 
 **Optional Arguments:**
 * `--cache-dir` - The directory to which the Action was previously downloaded.

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/github/codeql-action-sync/internal/cachedirectory"
+	"github.com/github/codeql-action-sync/internal/environment"
 	"github.com/github/codeql-action-sync/internal/push"
 	"github.com/github/codeql-action-sync/internal/version"
 	"github.com/spf13/cobra"
@@ -31,8 +34,13 @@ var pushFlags = pushFlagFields{}
 func (f *pushFlagFields) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.destinationURL, "destination-url", "", "The URL of the GitHub Enterprise instance to push to.")
 	cmd.MarkFlagRequired("destination-url")
-	cmd.Flags().StringVar(&f.destinationToken, "destination-token", "", "A token to access the API on the GitHub Enterprise instance.")
-	cmd.MarkFlagRequired("destination-token")
+	cmd.Flags().StringVar(&f.destinationToken, "destination-token", "", "A token to access the API on the GitHub Enterprise instance (can also be provided by setting the "+environment.DestinationToken+" environment variable).")
+	if f.destinationToken == "" {
+		f.destinationToken = os.Getenv(environment.DestinationToken)
+		if f.destinationToken == "" {
+			cmd.MarkFlagRequired("destination-token")
+		}
+	}
 	cmd.Flags().StringVar(&f.destinationRepository, "destination-repository", "github/codeql-action", "The name of the repository to create on GitHub Enterprise.")
 	cmd.Flags().StringVar(&f.actionsAdminUser, "actions-admin-user", "actions-admin", "The name of the Actions admin user.")
 	cmd.Flags().BoolVar(&f.force, "force", false, "Replace the existing repository even if it was not created by the sync tool.")

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -1,0 +1,5 @@
+package environment
+
+const environmentPrefix = "CODEQL_ACTION_SYNC_TOOL_"
+
+const DestinationToken = environmentPrefix + "DESTINATION_TOKEN"


### PR DESCRIPTION
This allows specifying the destination token as an environment variable instead of a CLI flag. This should be more secure if you're running the sync tool automatically or from a shared machine where someone might be able to access the process list.