### PR TITLE
Ignore the cache directory to make it easier to build and run the tool from the root of the repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/cache/
 /codeql-action-sync
 /dist/
 /pkged.go


### PR DESCRIPTION
This makes it so you can just build and run the tool from the root of the repository without overriding the cache directory, and without creating files that Git then wants to check in.