### PR TITLE
Add an integration test for GitHub Enterprise Server.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,24 @@ jobs:
       - name: Test
         run: go test ./...
 
+  integration_ghes:
+    name: Integration Test (GitHub Enterprise Server)
+    runs-on: ubuntu-20.04
+    if: ${{ github.event != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.7
+      - name: Build
+        run: go build
+      - name: Test
+        run: ./codeql-action-sync sync --destination-url https://ghe.io/ --destination-repository codeql-action-sync-tool/integration-test
+        env:
+          CODEQL_ACTION_SYNC_TOOL_DESTINATION_TOKEN: ${{ secrets.INTEGRATION_TEST_GHES_TOKEN }}
+
   lint:
     name: Lint
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This runs the sync tool against GitHub Enterprise Server for merges to main as well as internal PRs.