### PR TITLE
Add a hidden flag to fetch from an alternative Git source.

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -13,16 +13,19 @@ var pullCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		return pull.Pull(cmd.Context(), cacheDirectory, pullFlags.sourceToken)
+		return pull.Pull(cmd.Context(), cacheDirectory, pullFlags.sourceToken, pullFlags.sourceURL)
 	},
 }
 
 type pullFlagFields struct {
 	sourceToken string
+	sourceURL   string
 }
 
 var pullFlags = pullFlagFields{}
 
 func (f *pullFlagFields) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.sourceToken, "source-token", "", "A token to access the API of GitHub.com. This is normally not required, but can be provided if you have issues with API rate limiting.")
+	cmd.Flags().StringVar(&f.sourceURL, "source-url", "", "Use a custom Git URL for fetching the Action repository contents from. The CodeQL bundles will still be fetched from GitHub.com.")
+	cmd.Flags().MarkHidden("source-url")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -14,7 +14,7 @@ var syncCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		err := pull.Pull(cmd.Context(), cacheDirectory, pullFlags.sourceToken)
+		err := pull.Pull(cmd.Context(), cacheDirectory, pullFlags.sourceToken, pullFlags.sourceURL)
 		if err != nil {
 			return err
 		}

--- a/internal/pull/pull.go
+++ b/internal/pull/pull.go
@@ -29,7 +29,7 @@ import (
 
 const sourceOwner = "github"
 const sourceRepository = "codeql-action"
-const sourceURL = "https://github.com/" + sourceOwner + "/" + sourceRepository + ".git"
+const defaultSourceURL = "https://github.com/" + sourceOwner + "/" + sourceRepository + ".git"
 
 var relevantReferences = regexp.MustCompile("^refs/(heads|tags)/(main|v\\d+)$")
 
@@ -254,7 +254,7 @@ func (pullService *pullService) pullReleases() error {
 	return nil
 }
 
-func Pull(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, sourceToken string) error {
+func Pull(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, sourceToken string, sourceURL string) error {
 	err := cacheDirectory.CheckOrCreateVersionFile(true, version.Version())
 	if err != nil {
 		return err
@@ -270,6 +270,10 @@ func Pull(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, sou
 			&oauth2.Token{AccessToken: sourceToken},
 		)
 		tokenClient = oauth2.NewClient(ctx, tokenSource)
+	}
+
+	if sourceURL == "" {
+		sourceURL = defaultSourceURL
 	}
 
 	pullService := pullService{


### PR DESCRIPTION
This allows fetching Git resources from a mirror or local repository. This will allow creating pre-packaged bundles of the CodeQL Action repository for a specific Enterprise Server release rather than always using the latest state of the repository.