### PR TITLE
Update Go to the latest version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.18.0
       - name: Install Pkger
         run: go install --mod=readonly github.com/markbates/pkger/cmd/pkger
       - name: Build
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.18.0
       - name: Test
         run: go test ./...
 
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.18.0
       - name: Build
         run: go build
       - name: Test
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.18.0
       - name: Check Modules
         run: |
           go mod tidy
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.18.0
       - name: Setup licensedci
         uses: jonabc/setup-licensed@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.18.0
       - name: Install Pkger
         run: go install --mod=readonly github.com/markbates/pkger/cmd/pkger
       - name: Release


### PR DESCRIPTION
This hopefully fixes the build error from #62. I'm not sure why the integration tests are failing. That seems like an issue with the Enterprise Server instance we're testing against.