### PR TITLE
Add a hidden push option for specifying the destination Git URL

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -16,7 +16,7 @@ var pushCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		version.LogVersion()
 		cacheDirectory := cachedirectory.NewCacheDirectory(rootFlags.cacheDir)
-		return push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.actionsAdminUser, pushFlags.force, pushFlags.pushSSH)
+		return push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.actionsAdminUser, pushFlags.force, pushFlags.pushSSH, pushFlags.gitURL)
 	},
 }
 
@@ -27,6 +27,7 @@ type pushFlagFields struct {
 	actionsAdminUser      string
 	force                 bool
 	pushSSH               bool
+	gitURL                string
 }
 
 var pushFlags = pushFlagFields{}
@@ -45,4 +46,6 @@ func (f *pushFlagFields) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.actionsAdminUser, "actions-admin-user", "actions-admin", "The name of the Actions admin user.")
 	cmd.Flags().BoolVar(&f.force, "force", false, "Replace the existing repository even if it was not created by the sync tool.")
 	cmd.Flags().BoolVar(&f.pushSSH, "push-ssh", false, "Push Git contents over SSH rather than HTTPS. To use this option you must have SSH access to your GitHub Enterprise instance configured.")
+	cmd.Flags().StringVar(&f.gitURL, "git-url", "", "Use a custom Git URL for pushing the Action repository contents to.")
+	cmd.Flags().MarkHidden("git-url")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,7 +18,7 @@ var syncCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.actionsAdminUser, pushFlags.force, pushFlags.pushSSH)
+		err = push.Push(cmd.Context(), cacheDirectory, pushFlags.destinationURL, pushFlags.destinationToken, pushFlags.destinationRepository, pushFlags.actionsAdminUser, pushFlags.force, pushFlags.pushSSH, pushFlags.gitURL)
 		if err != nil {
 			return err
 		}

--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -53,6 +53,7 @@ type pushService struct {
 	aegis                      bool
 	force                      bool
 	pushSSH                    bool
+	gitURL                     string
 }
 
 func (pushService *pushService) createRepository() (*github.Repository, error) {
@@ -163,9 +164,12 @@ func (pushService *pushService) createRepository() (*github.Repository, error) {
 }
 
 func (pushService *pushService) pushGit(repository *github.Repository, initialPush bool) error {
-	remoteURL := repository.GetCloneURL()
-	if pushService.pushSSH {
-		remoteURL = repository.GetSSHURL()
+	remoteURL := pushService.gitURL
+	if remoteURL == "" {
+		remoteURL = repository.GetCloneURL()
+		if pushService.pushSSH {
+			remoteURL = repository.GetSSHURL()
+		}
 	}
 	if initialPush {
 		log.Debugf("Pushing Git releases to %s...", remoteURL)
@@ -366,7 +370,7 @@ func (pushService *pushService) pushReleases() error {
 	return nil
 }
 
-func Push(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, destinationURL string, destinationToken string, destinationRepository string, actionsAdminUser string, force bool, pushSSH bool) error {
+func Push(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, destinationURL string, destinationToken string, destinationRepository string, actionsAdminUser string, force bool, pushSSH bool, gitURL string) error {
 	err := cacheDirectory.CheckOrCreateVersionFile(false, version.Version())
 	if err != nil {
 		return err
@@ -424,6 +428,7 @@ func Push(ctx context.Context, cacheDirectory cachedirectory.CacheDirectory, des
 		aegis:                      aegis,
 		force:                      force,
 		pushSSH:                    pushSSH,
+		gitURL:                     gitURL,
 	}
 
 	repository, err := pushService.createRepository()


### PR DESCRIPTION
In some special cases we want to override how we talk to Git, e.g. to talk to babeld directly if we're syncing the CodeQL Action before an instance has been full set up. This adds a flag for doing that.