### PR TITLE
Check release references exist in the cache before trying to push them.

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -215,7 +215,12 @@ func (pushService *pushService) pushGit(repository *github.Repository, initialPu
 		}
 		initialRefSpecs := []config.RefSpec{}
 		for _, releasePathStat := range releasePathStats {
-			initialRefSpecs = append(initialRefSpecs, config.RefSpec("+refs/tags/"+releasePathStat.Name()+":refs/tags/"+releasePathStat.Name()))
+			tagReferenceName := plumbing.NewTagReferenceName(releasePathStat.Name())
+			_, err := gitRepository.Reference(tagReferenceName, true)
+			if err != nil {
+				return errors.Wrapf(err, "Error finding local tag reference %s.", tagReferenceName)
+			}
+			initialRefSpecs = append(initialRefSpecs, config.RefSpec("+"+tagReferenceName.String()+":"+tagReferenceName.String()))
 		}
 		refSpecBatches = append(refSpecBatches, initialRefSpecs)
 	} else {


### PR DESCRIPTION
I realized this could actually lead to some slightly confusing behavior if tags are missing for some reason. It's better if we fail immediately in this case.