### PR TITLE
Add a counter to show how many bundles have been pushed and how many are left.

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -348,9 +348,9 @@ func (pushService *pushService) pushReleases() error {
 	if err != nil {
 		return errors.Wrap(err, "Error reading releases.")
 	}
-	for _, releasePathStat := range releasePathStats {
+	for index, releasePathStat := range releasePathStats {
 		releaseName := releasePathStat.Name()
-		log.Debugf("Pushing CodeQL bundles release %s...", releaseName)
+		log.Debugf("Pulling CodeQL bundle %s (%d/%d)...", releaseName, index+1, len(releasePathStats))
 		release, err := pushService.createOrUpdateRelease(releaseName)
 		if err != nil {
 			return err


### PR DESCRIPTION
This is similar to what we do during pulling to show progress.