### PR TITLE
Move an error check to a more correct location.

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -324,14 +324,14 @@ func (pushService *pushService) createOrUpdateReleaseAsset(release *github.Repos
 	}
 	log.Debugf("Uploading release asset %s...", assetPathStat.Name())
 	assetFile, err := os.Open(pushService.cacheDirectory.AssetPath(release.GetTagName(), assetPathStat.Name()))
+	if err != nil {
+		return errors.Wrap(err, "Error opening release asset.")
+	}
 	defer assetFile.Close()
 	progressReader := &ioprogress.Reader{
 		Reader:   assetFile,
 		Size:     assetPathStat.Size(),
 		DrawFunc: ioprogress.DrawTerminalf(os.Stderr, ioprogress.DrawTextFormatBytes),
-	}
-	if err != nil {
-		return errors.Wrap(err, "Error opening release asset.")
 	}
 	_, _, err = pushService.uploadReleaseAsset(release, assetPathStat, progressReader)
 	if err != nil {


### PR DESCRIPTION
staticcheck seems to say that it's preferable to check for errors before a `defer .Close()`, which I suppose does make sense so this PR makes that change.