### PR TITLE
:hamster: :bug: fix cachedirectory.go to allow an existing empty dir as cache

### DIFF
--- a/internal/cachedirectory/cachedirectory.go
+++ b/internal/cachedirectory/cachedirectory.go
@@ -2,7 +2,6 @@ package cachedirectory
 
 import (
 	usererrors "errors"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -108,19 +107,17 @@ func (cacheDirectory *CacheDirectory) CheckOrCreateVersionFile(pull bool, versio
 			if !isAccessible {
 				return errors.Wrap(err, "Cache dir exists, but the current user can't write to it.")
 			}
-
-			isEmpty, err := isEmptyDirectory(cacheDirectory.path)
+		}
+		isEmpty, err := isEmptyDirectory(cacheDirectory.path)
+		if err != nil {
+			return err
+		}
+		if isEmpty {
+			err = ioutil.WriteFile(cacheVersionFilePath, []byte(version), 0644)
 			if err != nil {
-				return err
-			}
-			if isEmpty {
-				err = ioutil.WriteFile(cacheVersionFilePath, []byte(version), 0644)
-				if err != nil {
-					return errors.Wrap(err, "Could not create cache version file.")
-				}
+				return errors.Wrap(err, "Could not create cache version file.")
 			}
 			return nil
-			
 		}
 		return usererrors.New(errorNotACacheOrEmpty)
 	}

--- a/internal/cachedirectory/cachedirectory.go
+++ b/internal/cachedirectory/cachedirectory.go
@@ -35,7 +35,7 @@ func isAccessibleDirectory(path string) (bool, error) {
 		}
 		return false, errors.Wrapf(err, "Could not access directory %s.", path)
 	}
-	
+
 	return true, nil
 }
 

--- a/internal/cachedirectory/cachedirectory_test.go
+++ b/internal/cachedirectory/cachedirectory_test.go
@@ -89,6 +89,18 @@ func TestCreateCacheDirectoryWithTrailingSlash(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUseProvidedEmptyCacheDirectory(t *testing.T) {
+	temporaryDirectory := test.CreateTemporaryDirectory(t)
+	cacheDirectoryPath := path.Join(temporaryDirectory, "cache")
+	err := os.MkdirAll(cacheDirectoryPath, 0755)
+	require.NoError(t, err)
+	cacheDirectory := NewCacheDirectory(cacheDirectoryPath)
+	err = cacheDirectory.CheckOrCreateVersionFile(true, aVersion)
+	require.NoError(t, err)
+	cacheVersionFilePath := cacheDirectory.versionFilePath()
+	require.FileExists(t, cacheVersionFilePath)
+}
+
 func TestLocking(t *testing.T) {
 	temporaryDirectory := test.CreateTemporaryDirectory(t)
 	cacheDirectory := NewCacheDirectory(path.Join(temporaryDirectory, "cache"))


### PR DESCRIPTION
# Requirement

* For the command below, if the desired cache dir `/var/tmp/codeqltmp` exists and is empty, it current version fails.

```console
codeql-action-sync --cache-dir '/var/tmp/codeqltmp' --destination-url 'https://git.company.com' --destination-repository 'seceng-devsecops-platform/github-codeql-action-tester'
```

* The solution to the issue #122 is to verify if the dir is empty, and it's writable for the current process in phases instead of the binary check done in the current code.
* I have split the existing function into 3 other to better control the flow

# :octocat: Issue https://github.com/github/codeql-action-sync-tool/issues/122

* For the cases of cache directories that need to exist before, the code fails with the error message that it can't create the directory. For example, cache dir from github workflows.

This code change makes sure to verify the cases if it's empty or not.

# ✅ New Test Case - TestUseProvidedEmptyCacheDirectory

```go
$ go test -v ./internal/cachedirectory -test.run ^\QTestUseProvidedEmptyCacheDirectory\E$
testing: warning: no tests to run
PASS
ok      github.com/github/codeql-action-sync/internal/cachedirectory    0.932s [no tests to run]
```

# ✅ Regression Test Cases

```go
$ go test -v ./internal/cachedirectory
=== RUN   TestCreateCacheDirectoryDuringPullThenReuse
--- PASS: TestCreateCacheDirectoryDuringPullThenReuse (0.01s)
=== RUN   TestOverwriteCacheDirectoryIfVersionMismatchDuringPull
--- PASS: TestOverwriteCacheDirectoryIfVersionMismatchDuringPull (0.01s)
=== RUN   TestErrorIfVersionMismatchDuringPush
--- PASS: TestErrorIfVersionMismatchDuringPush (0.00s)
=== RUN   TestErrorIfCacheIsNonEmptyAndNotCache
--- PASS: TestErrorIfCacheIsNonEmptyAndNotCache (0.00s)
=== RUN   TestErrorIfCacheParentDoesNotExist
--- PASS: TestErrorIfCacheParentDoesNotExist (0.00s)
=== RUN   TestErrorIfPushNonCache
--- PASS: TestErrorIfPushNonCache (0.00s)
=== RUN   TestErrorIfPushNonExistent
--- PASS: TestErrorIfPushNonExistent (0.00s)
=== RUN   TestCreateCacheDirectoryWithTrailingSlash
--- PASS: TestCreateCacheDirectoryWithTrailingSlash (0.00s)
=== RUN   TestUseProvidedEmptyCacheDirectory
--- PASS: TestUseProvidedEmptyCacheDirectory (0.00s)
=== RUN   TestLocking
--- PASS: TestLocking (0.00s)
PASS
ok  	github.com/github/codeql-action-sync/internal/cachedirectory	0.867s
```

# 🏗️ Verification

* I have built the branch binaries and pushed to https://github.com/marcellodesales/codeql-action-sync-tool/releases/tag/v1.0.12
* I have also executed this in our Enterprise appliance with the workflow cache (existing empty directory) specified in the related ticket #122

<img width="1717" alt="Screenshot 2025-01-28 at 6 45 32 PM" src="https://github.com/user-attachments/assets/7e5137cb-7112-4249-a1c2-cdc36e8bacb6" />
