### PR TITLE
Fix push batches to 25 refspecs at once

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -166,7 +166,7 @@ func (pushService *pushService) createRepository() (*github.Repository, error) {
 func splitLargeRefSpecs(refSpecs []config.RefSpec) [][]config.RefSpec {
 	splitRefSpecs := [][]config.RefSpec{}
 	for i := 0; i < len(refSpecs); i += 25 {
-		end := i + 100
+		end := i + 25
 		if end > len(refSpecs) {
 			end = len(refSpecs)
 		}


### PR DESCRIPTION
https://github.com/github/codeql-action-sync-tool/pull/129 introduced this logic, however it created batches of 100 refspecs with overlaps between the pushes (0-100, 25-125 etc.) causing unnecessary duplication of work.